### PR TITLE
Various API improvements to the Tracer

### DIFF
--- a/pkg/tracer/event.go
+++ b/pkg/tracer/event.go
@@ -11,14 +11,9 @@ import (
 */
 import "C"
 
-func tcpV4ToGo(data *[]byte) (ret TcpV4) {
+// tcpV4ToGo maps a given TCP IPv4 byte slice to a TCPEvent.
+func tcpV4ToGo(data *[]byte) TCPEvent {
 	eventC := (*C.struct_tcp_ipv4_event_t)(unsafe.Pointer(&(*data)[0]))
-
-	ret.Timestamp = uint64(eventC.timestamp)
-	ret.CPU = uint64(eventC.cpu)
-	ret.Type = EventType(eventC._type)
-	ret.Pid = uint32(eventC.pid & 0xffffffff)
-	ret.Comm = C.GoString(&eventC.comm[0])
 
 	saddrbuf := make([]byte, 4)
 	daddrbuf := make([]byte, 4)
@@ -26,30 +21,25 @@ func tcpV4ToGo(data *[]byte) (ret TcpV4) {
 	binary.LittleEndian.PutUint32(saddrbuf, uint32(eventC.saddr))
 	binary.LittleEndian.PutUint32(daddrbuf, uint32(eventC.daddr))
 
-	ret.SAddr = net.IPv4(saddrbuf[0], saddrbuf[1], saddrbuf[2], saddrbuf[3])
-	ret.DAddr = net.IPv4(daddrbuf[0], daddrbuf[1], daddrbuf[2], daddrbuf[3])
-
-	ret.SPort = uint16(eventC.sport)
-	ret.DPort = uint16(eventC.dport)
-	ret.NetNS = uint32(eventC.netns)
-	ret.Fd = uint32(eventC.fd)
-
-	return
+	return TCPEvent{
+		Timestamp: uint64(eventC.timestamp),
+		CPU: uint64(eventC.cpu),
+		Type: EventType(eventC._type),
+		Pid: uint32(eventC.pid & 0xffffffff),
+		Comm: C.GoString(&eventC.comm[0]),
+		TCPType: IPv4,
+		SAddr: net.IPv4(saddrbuf[0], saddrbuf[1], saddrbuf[2], saddrbuf[3]),
+		DAddr: net.IPv4(daddrbuf[0], daddrbuf[1], daddrbuf[2], daddrbuf[3]),
+		SPort: uint16(eventC.sport),
+		DPort: uint16(eventC.dport),
+		NetNS: uint32(eventC.netns),
+		Fd: uint32(eventC.fd),
+	}
 }
 
-func tcpV4Timestamp(data *[]byte) uint64 {
-	eventC := (*C.struct_tcp_ipv4_event_t)(unsafe.Pointer(&(*data)[0]))
-	return uint64(eventC.timestamp)
-}
-
-func tcpV6ToGo(data *[]byte) (ret TcpV6) {
+// tcpV6ToGo maps a given TCP IPv6 byte slice to a TCPEvent.
+func tcpV6ToGo(data *[]byte) TCPEvent {
 	eventC := (*C.struct_tcp_ipv6_event_t)(unsafe.Pointer(&(*data)[0]))
-
-	ret.Timestamp = uint64(eventC.timestamp)
-	ret.CPU = uint64(eventC.cpu)
-	ret.Type = EventType(eventC._type)
-	ret.Pid = uint32(eventC.pid & 0xffffffff)
-	ret.Comm = C.GoString(&eventC.comm[0])
 
 	saddrbuf := make([]byte, 16)
 	daddrbuf := make([]byte, 16)
@@ -59,18 +49,36 @@ func tcpV6ToGo(data *[]byte) (ret TcpV6) {
 	binary.LittleEndian.PutUint64(daddrbuf, uint64(eventC.daddr_h))
 	binary.LittleEndian.PutUint64(daddrbuf[8:], uint64(eventC.daddr_l))
 
-	ret.SAddr = net.IP(saddrbuf)
-	ret.DAddr = net.IP(daddrbuf)
+	return TCPEvent{
+		Timestamp: uint64(eventC.timestamp),
+		CPU: uint64(eventC.cpu),
+		Type: EventType(eventC._type),
+		Pid: uint32(eventC.pid & 0xffffffff),
+		Comm: C.GoString(&eventC.comm[0]),
+		TCPType: IPv6,
+		SAddr: net.IP(saddrbuf),
+		DAddr: net.IP(daddrbuf),
+		SPort: uint16(eventC.sport),
+		DPort: uint16(eventC.dport),
+		NetNS: uint32(eventC.netns),
+		Fd: uint32(eventC.fd),
+	}
+}
 
-	ret.SPort = uint16(eventC.sport)
-	ret.DPort = uint16(eventC.dport)
-	ret.NetNS = uint32(eventC.netns)
-	ret.Fd = uint32(eventC.fd)
-
-	return
+func tcpV4Timestamp(data *[]byte) uint64 {
+	eventC := (*C.struct_tcp_ipv4_event_t)(unsafe.Pointer(&(*data)[0]))
+	return uint64(eventC.timestamp)
 }
 
 func tcpV6Timestamp(data *[]byte) uint64 {
 	eventC := (*C.struct_tcp_ipv6_event_t)(unsafe.Pointer(&(*data)[0]))
 	return uint64(eventC.timestamp)
+}
+
+func newEvent(t TCPEvent) Event {
+	return Event{TCPEvent: t}
+}
+
+func newEventError(err error) Event {
+	return Event{Error: err}
 }

--- a/pkg/tracer/event_common.go
+++ b/pkg/tracer/event_common.go
@@ -4,6 +4,7 @@ import (
 	"net"
 )
 
+// EventType represents the type of TCP event that occurred, as one of the below.
 type EventType uint32
 
 // These constants should be in sync with the equivalent definitions in the ebpf program.
@@ -14,6 +15,7 @@ const (
 	EventFdInstall           = 4
 )
 
+// String returns a string representation of the event type.
 func (e EventType) String() string {
 	switch e {
 	case EventConnect:
@@ -29,11 +31,20 @@ func (e EventType) String() string {
 	}
 }
 
-// TcpV4 represents a TCP event (connect, accept or close) on IPv4
-type TcpV4 struct {
+// TCPType represents whether the connection was IPv4 or IPv6.
+type TCPType string
+
+const (
+	IPv4 TCPType = "IPv4"
+	IPv6 TCPType = "IPv6"
+)
+
+// TCPEvent represents a TCP event (connect, accept or close) on IPv4 or IPv6.
+type TCPEvent struct {
 	Timestamp uint64    // Monotonic timestamp
 	CPU       uint64    // CPU index
 	Type      EventType // connect, accept or close
+	TCPType   TCPType   // IPv4 or IPv6
 	Pid       uint32    // Process ID, who triggered the event
 	Comm      string    // The process command (as in /proc/$pid/comm)
 	SAddr     net.IP    // Local IP address
@@ -44,17 +55,9 @@ type TcpV4 struct {
 	Fd        uint32    // File descriptor for fd_install events
 }
 
-// TcpV6 represents a TCP event (connect, accept or close) on IPv6
-type TcpV6 struct {
-	Timestamp uint64    // Monotonic timestamp
-	CPU       uint64    // CPU index
-	Type      EventType // connect, accept or close
-	Pid       uint32    // Process ID, who triggered the event
-	Comm      string    // The process command (as in /proc/$pid/comm)
-	SAddr     net.IP    // Local IP address
-	DAddr     net.IP    // Remote IP address
-	SPort     uint16    // Local TCP port
-	DPort     uint16    // Remote TCP port
-	NetNS     uint32    // Network namespace ID (as in /proc/$pid/ns/net)
-	Fd        uint32    // File descriptor for fd_install events
+// Event represents a message on the event channel for consumption.
+// It includes an Error field in case something goes wrong.
+type Event struct {
+	TCPEvent
+	Error error
 }

--- a/pkg/tracer/interface.go
+++ b/pkg/tracer/interface.go
@@ -1,0 +1,16 @@
+package tracer
+
+// Tracer represents the TCP tracing interface.
+// Tracer returns new tcp events along a channel for convenient consumption.
+type Tracer interface {
+	// Start starts the TCP tracer.
+	Start()
+	// Events sends all new TCP events along a channel.
+	Events() <-chan Event
+	// Closed indicates when the channel has been closed.
+	Closed() <-chan struct{}
+	// Close closes the TCP tracer.
+	Close()
+
+	AddFdInstallWatcher(uint32) error
+}

--- a/pkg/tracer/tracer_cb.go
+++ b/pkg/tracer/tracer_cb.go
@@ -1,8 +1,0 @@
-package tracer
-
-type Callback interface {
-	TCPEventV4(TcpV4)
-	TCPEventV6(TcpV6)
-	LostV4(uint64)
-	LostV6(uint64)
-}

--- a/pkg/tracer/tracer_unsupported.go
+++ b/pkg/tracer/tracer_unsupported.go
@@ -6,22 +6,8 @@ import (
 	"fmt"
 )
 
-type Tracer struct{}
-
-func TracerAsset() ([]byte, error) {
+// New sets up a new Tracer.
+// This returns a dummy Tracer for non-linux systems to compile.
+func New() (Tracer, error) {
 	return nil, fmt.Errorf("not supported on non-Linux systems")
-}
-
-func NewTracer(cb Callback) (*Tracer, error) {
-	return nil, fmt.Errorf("not supported on non-Linux systems")
-}
-func (t *Tracer) Start() {
-}
-func (t *Tracer) AddFdInstallWatcher(pid uint32) (err error) {
-	return fmt.Errorf("not supported on non-Linux systems")
-}
-func (t *Tracer) RemoveFdInstallWatcher(pid uint32) (err error) {
-	return fmt.Errorf("not supported on non-Linux systems")
-}
-func (t *Tracer) Stop() {
 }

--- a/tests/tracer.go
+++ b/tests/tracer.go
@@ -5,61 +5,16 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
+	"strconv"
 
 	"github.com/weaveworks/tcptracer-bpf/pkg/tracer"
 )
 
 var watchFdInstallPids string
 
-type tcpEventTracer struct {
-	lastTimestampV4 uint64
-	lastTimestampV6 uint64
-}
-
-func (t *tcpEventTracer) TCPEventV4(e tracer.TcpV4) {
-	if e.Type == tracer.EventFdInstall {
-		fmt.Printf("%v cpu#%d %s %v %s %v\n",
-			e.Timestamp, e.CPU, e.Type, e.Pid, e.Comm, e.Fd)
-	} else {
-		fmt.Printf("%v cpu#%d %s %v %s %v:%v %v:%v %v\n",
-			e.Timestamp, e.CPU, e.Type, e.Pid, e.Comm, e.SAddr, e.SPort, e.DAddr, e.DPort, e.NetNS)
-	}
-
-	if t.lastTimestampV4 > e.Timestamp {
-		fmt.Printf("ERROR: late event!\n")
-		os.Exit(1)
-	}
-
-	t.lastTimestampV4 = e.Timestamp
-}
-
-func (t *tcpEventTracer) TCPEventV6(e tracer.TcpV6) {
-	fmt.Printf("%v cpu#%d %s %v %s %v:%v %v:%v %v\n",
-		e.Timestamp, e.CPU, e.Type, e.Pid, e.Comm, e.SAddr, e.SPort, e.DAddr, e.DPort, e.NetNS)
-
-	if t.lastTimestampV6 > e.Timestamp {
-		fmt.Printf("ERROR: late event!\n")
-		os.Exit(1)
-	}
-
-	t.lastTimestampV6 = e.Timestamp
-}
-
-func (t *tcpEventTracer) LostV4(count uint64) {
-	fmt.Printf("ERROR: lost %d events!\n", count)
-	os.Exit(1)
-}
-
-func (t *tcpEventTracer) LostV6(count uint64) {
-	fmt.Printf("ERROR: lost %d events!\n", count)
-	os.Exit(1)
-}
-
 func init() {
 	flag.StringVar(&watchFdInstallPids, "monitor-fdinstall-pids", "", "a comma-separated list of pids that need to be monitored for fdinstall events")
-
 	flag.Parse()
 }
 
@@ -69,33 +24,39 @@ func main() {
 		os.Exit(1)
 	}
 
-	t, err := tracer.NewTracer(&tcpEventTracer{})
+	t, err := tracer.New()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-
 	t.Start()
-
 	for _, p := range strings.Split(watchFdInstallPids, ",") {
 		if p == "" {
 			continue
 		}
-
 		pid, err := strconv.ParseUint(p, 10, 32)
 		if err != nil {
+
 			fmt.Fprintf(os.Stderr, "Invalid pid: %v\n", err)
+
 			os.Exit(1)
 		}
 		fmt.Printf("Monitor fdinstall events for pid %d\n", pid)
 		t.AddFdInstallWatcher(uint32(pid))
 	}
 
+	defer t.Close()
 	fmt.Printf("Ready\n")
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, os.Kill)
-
-	<-sig
-	t.Stop()
+	for {
+		select {
+		case e := <-t.Events():
+			fmt.Printf("%v cpu#%d %s %v %s %v:%v %v:%v %v\n",
+				e.Timestamp, e.CPU, e.Type, e.Pid, e.Comm, e.SAddr, e.SPort, e.DAddr, e.DPort, e.NetNS)
+		case <-sig:
+			return
+		}
+	}
 }


### PR DESCRIPTION
Drafting some potential improvements that can be made to the Tracer API. The Tracer callback in weaveworks/tcptracer-bpf is a little difficult to use because it is a non-blocking callback. A more Go-idiomatic approach would be to return a channel (see Cherami, Kafka Uber libs, etc.) to read from, so a blocking select {} block can process each incoming connection.

Other cleanup includes squashing the TCP structs into a single TCPEvent type, etc.